### PR TITLE
Make Build Work on Stable

### DIFF
--- a/src/collectors/silent/mod.rs
+++ b/src/collectors/silent/mod.rs
@@ -6,7 +6,7 @@ use std::fmt;
 // have any error path so this for now.
 
 #[derive(Debug)]
-pub struct NoError { }
+pub struct NoError;
 
 impl fmt::Display for NoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -22,15 +22,15 @@ impl error::Error for NoError {
 
 impl SilentCollector {
     pub fn new() -> SilentCollector {
-        SilentCollector { }
+        SilentCollector
     }
 }
 
-pub struct SilentCollector { }
+pub struct SilentCollector;
 
 impl super::Collector for SilentCollector {
     type Error = NoError;
-    
+
     #[allow(unused_variables)]
     fn dispatch(&self, events: &[events::Event]) -> Result<(), Self::Error> {
         Ok(())


### PR DESCRIPTION
_Tiny PR ahead_

Just removing the braces on empty structs so `emit` compiles on the `stable` channel :)